### PR TITLE
Using standard C library as default library

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ To build with the smaller C libraries, modify the application configuration file
 }
 ```
 
+If the build system throws an error when compiling with the small C library, you can find more information [here]( https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/program-setup/bare_metal/c_small_libs.md).
+
 #### Using Mbed minimal printf library
 
 Mbed OS offers a smaller `printf()` alternative. The [minimal printf](https://github.com/ARMmbed/mbed-os/blob/master/platform/source/minimal-printf/README.md) library implements a subset of the `v/s/f/printf` function family, and you can disable floating points to save additional code size.

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,6 @@
     "requires": ["bare-metal"],
     "target_overrides": {
       "*": {  
-        "target.c_lib": "small",
         "target.printf_lib": "minimal-printf",
         "platform.minimal-printf-enable-floating-point": "false",
         "platform.stdio-minimal-console-only": true


### PR DESCRIPTION
The smaller C library is not supported on all targets and all toolchains so `"target.c_lib": "small"` is removed from `mbed_app.json`. 