### PR TITLE
Update for mbed-os-6.15.1

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938
+https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.15.1 release of mbed-os. 